### PR TITLE
fix allOf wrong type error message

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -891,7 +891,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 		} else {
 			return errors.New(formatErrorDescription(
 				Locale.MustBeOfAn(),
-				ErrorDetails{"x": KEY_ANY_OF, "y": TYPE_ARRAY},
+				ErrorDetails{"x": KEY_ALL_OF, "y": TYPE_ARRAY},
 			))
 		}
 	}

--- a/schema_test.go
+++ b/schema_test.go
@@ -380,3 +380,12 @@ func TestIncorrectRef(t *testing.T) {
 	assert.Nil(t, s)
 	assert.Equal(t, "Object has no key 'fail'", err.Error())
 }
+
+func TestAllOfIncorrectTypeErrorMessage(t *testing.T) {
+	schemaLoader := NewStringLoader(`{"allOf": {}}`)
+
+	s, err := NewSchema(schemaLoader)
+
+	assert.Nil(t, s)
+	assert.EqualError(t, err, "allOf must be of an array")
+}


### PR DESCRIPTION
## Synopsis

When `allOf` was not an array, library was returning an error saying `anyOf must be of an array`. This PR fixes this.