### PR TITLE
remove redundant err check

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -985,10 +985,6 @@ func (d *Schema) parseReference(documentNode interface{}, currentSchema *subSche
 	refdDocumentNode = dsp.Document
 	newSchema.draft = dsp.Draft
 
-	if err != nil {
-		return err
-	}
-
 	if !isKind(refdDocumentNode, reflect.Map, reflect.Bool) {
 		return errors.New(formatErrorDescription(
 			Locale.MustBeOfType(),
@@ -996,7 +992,7 @@ func (d *Schema) parseReference(documentNode interface{}, currentSchema *subSche
 		))
 	}
 
-	err = d.parseSchema(refdDocumentNode, newSchema)
+	3err = d.parseSchema(refdDocumentNode, newSchema)
 	if err != nil {
 		return err
 	}

--- a/schema.go
+++ b/schema.go
@@ -992,7 +992,7 @@ func (d *Schema) parseReference(documentNode interface{}, currentSchema *subSche
 		))
 	}
 
-	3err = d.parseSchema(refdDocumentNode, newSchema)
+	err = d.parseSchema(refdDocumentNode, newSchema)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Linter caught this as

     impossible condition: nil!=nil